### PR TITLE
Fixed different generation vector error

### DIFF
--- a/core/main.lua
+++ b/core/main.lua
@@ -24,7 +24,7 @@ function lovr.load()
     
     camera = {
         transform = lovr.math.vec3(),
-        position = lovr.math.vec3(),
+        position = lovr.math.newVec3(),
         movespeed = 10,
         pitch = 0,
         yaw = 0


### PR DESCRIPTION
Error:
Attempt to use a vector in a different generation than the one it was created in (vectors can not be saved into variables)

Stack:
main.lua:80: in function 'draw'
boot.lua:202: in function 'mirror'
boot.lua:179: in function <boot.lua:149>
[C]: in function 'xpcall'
